### PR TITLE
feat: add debug mode to use devtools

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,5 +1,15 @@
 #!/usr/bin/env node
-
+import inspector from 'node:inspector';
 import launcher from './launcher.js';
 
+// Parse command line arguments
+const args = process.argv.slice(2);
+const debugMode = args.includes('--debug') || args.includes('-d');
+
+// Enable inspector if debug mode is on
+if (debugMode) {
+    inspector.open(9229, 'localhost', true);
+}
+
+// Launch the game
 launcher();


### PR DESCRIPTION
### Description
- adds the ability to use node debuggers/dev tools when running the program as a bin/`npx` (ex. chrome devtools)
- introduces the `--debug|-d` flag which spawns the debugger/inspector websocket connection

### Example

<img width="1518" alt="Screenshot 2025-01-31 at 4 13 14 PM" src="https://github.com/user-attachments/assets/98bf088f-63a9-4bd7-85c4-9990285cf13e" />
