### PR TITLE
fix(rocknix): add node check and logging to run.sh

### DIFF
--- a/systems/rocknix/run.sh
+++ b/systems/rocknix/run.sh
@@ -1,10 +1,38 @@
 #!/bin/bash
 
+LOG_FILE="/roms/jsgames/.jsgamelauncher.log"
+
+log() {
+    echo "$(date '+%Y-%m-%d %H:%M:%S') - $1" >> "$LOG_FILE"
+}
+
 export LD_LIBRARY_PATH=/usr/lib
 
-source ~/.bash_profile
-nvm use 22
+# Source bash_profile for nvm
+if [ -f ~/.bash_profile ]; then
+    source ~/.bash_profile
+else
+    log "ERROR: ~/.bash_profile not found"
+fi
+
+# Try to use node 22 via nvm
+if command -v nvm &> /dev/null; then
+    nvm use 22 2>> "$LOG_FILE"
+else
+    log "WARNING: nvm not found, trying system node"
+fi
+
+# Check if node is available
+if ! command -v node &> /dev/null; then
+    log "ERROR: Node.js not found! Please run the installer again."
+    log "Try: curl -sL https://raw.githubusercontent.com/monteslu/jsgamelauncher/main/installers/install-rocknix.sh | bash"
+    exit 1
+fi
 
 cd /storage/jsgamelauncher
 
-node index.js $@
+log "Starting jsgamelauncher with: $@"
+node index.js "$@" 2>> "$LOG_FILE"
+EXIT_CODE=$?
+log "jsgamelauncher exited with code: $EXIT_CODE"
+exit $EXIT_CODE


### PR DESCRIPTION
Fixes #65

## Problem
When Node.js is missing or nvm fails to set it up, games fail silently with just a black screen and return to EmulationStation.

## Solution
- Add logging to `/roms/jsgames/.jsgamelauncher.log`
- Check if node exists before trying to run
- Log helpful error message with reinstall instructions if node is missing
- Log exit codes for debugging

Now users can check the log file to understand why games aren't launching.